### PR TITLE
docs: interactive debugging and standard output

### DIFF
--- a/src/workflows/snakemake.md
+++ b/src/workflows/snakemake.md
@@ -84,3 +84,4 @@ Inserting the following into a python script executed in a snakemake rule will t
 ```python
 import pdb; pdb.set_trace()
 ```
+Please note that you must not redirect the standard output to any log file, which you might have done before for other debugging purpose. If you do so, the python debugger will still interrupt the pipeline execution but you will not see the debugging shell, and thus be unable to interact with the program state or resume the execution.


### PR DESCRIPTION
I added a hint about redirecting standard output and interactive debugging with PDB, as others might run into the same problem without understanding why the debugging tools do not work for their workflow.